### PR TITLE
OBT-48 | Include alternate description section for Big PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 * [ ] Multiple files with code changes.
 * [ ] Multiple files just moved around.
 
-<!--- Detail all the points marked above. Refer to our [Team Tech Agreements](https://csmdigital.atlassian.net/wiki/spaces/CSMP/pages/2490695681/New+Team+Agreements#Team-Technical-Agreements.1) -> Big PRs for more info. -->
+<!--- Detail all the points marked above. Refer to "Big PRs" in https://csmdigital.atlassian.net/wiki/spaces/CSMP/pages/2490695681/New+Team+Agreements#Team-Technical-Agreements.1 for more info. -->
 
 ### Related issue
 <!--- Link to Jira ticket --->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,17 @@
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Description
-<!--- Describe your changes in detail -->
+<!--- Describe your changes in detail. If it's a Big PR, remove this section -->
+
+## Description (Big PR)
+<!--- Mark what's included in this PR and describe it. If it isn't a Big PR, remove this section -->
+* [ ] Multiple features (which ones? how were they tested/how to test?).
+* [ ] Change of the scope (why?).
+* [ ] Introduces breaking changes (which ones?).
+* [ ] Multiple files with code changes.
+* [ ] Multiple files just moved around.
+
+<!--- Detail all the points marked above. Refer to our [Team Tech Agreements](https://csmdigital.atlassian.net/wiki/spaces/CSMP/pages/2490695681/New+Team+Agreements#Team-Technical-Agreements.1) -> Big PRs for more info. -->
 
 ### Related issue
 <!--- Link to Jira ticket --->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,25 @@
-<!--- Provide a general summary of your changes in the Title above -->
+> [!NOTE]
+> _Provide a general summary of your changes in the Title above_
 
 ## Description
-<!--- Describe your changes in detail. If it's a Big PR, remove this section -->
+> [!NOTE]
+> _Describe your changes in detail. If it's a Big PR, remove this section_
 
 ## Description (Big PR)
-<!--- Mark what's included in this PR and describe it. If it isn't a Big PR, remove this section -->
+> [!NOTE]
+> _Mark what's included in this PR and describe it. If it isn't a Big PR, remove this section_
 * [ ] Multiple features (which ones? how were they tested/how to test?).
 * [ ] Change of the scope (why?).
 * [ ] Introduces breaking changes (which ones?).
 * [ ] Multiple files with code changes.
 * [ ] Multiple files just moved around.
 
-<!--- Detail all the points marked above. Refer to "Big PRs" in https://csmdigital.atlassian.net/wiki/spaces/CSMP/pages/2490695681/New+Team+Agreements#Team-Technical-Agreements.1 for more info. -->
+> [!NOTE]
+> Detail all the points marked above. Refer to "Big PRs" in [Team Agreements](https://csmdigital.atlassian.net/wiki/spaces/CSMP/pages/2490695681/New+Team+Agreements#Team-Technical-Agreements.1) for more info
 
 ### Related issue
-<!--- Link to Jira ticket --->
+> [!NOTE]
+> Link the related Jira ticket
 * [PRT-XXXX](https://csmdigital.atlassian.net/browse/PRT-XXXX)
 
 ### Type of change


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Adds a new section for Big PRs. The idea is to choose between the existing "Description" section for normal PRs or the new "Description (Big PR)" when we're creating a big PR. If it's a big one, we have a set of things to check that should be detailed below the checklist.

### Related issue
<!--- Link to Jira ticket --->
* [OBT-48](https://csmdigital.atlassian.net/browse/OBT-48)

### Type of change
<!-- select all that apply -->
* [x] feature: new capabilities.
* [ ] fix: bug, hotfix, etc.
* [ ] refactor: enhancements.
* [ ] style: changes in styles.
* [ ] cicd: helm, docker & cicd adjustments.
* [ ] other: docs, tests.

### This PR is linked to a change in
<!--- select all that apply, if any --->
- [ ] **Content model**
- [ ] **Database**
- [ ] **Infrastructure**
- [ ] **Other**:

### Visual evidence
<!--- some screenshots or log traces with the effects --->

### Additional comments (optional) 
<!--- any other information that would be useful --->


[OBT-48]: https://csmdigital.atlassian.net/browse/OBT-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ